### PR TITLE
Padroniza a saída CSV para classes de publicações

### DIFF
--- a/scriptLattes/producoesBibliograficas/artigoEmPeriodico.py
+++ b/scriptLattes/producoesBibliograficas/artigoEmPeriodico.py
@@ -267,9 +267,15 @@ class ArtigoEmPeriodico:
 
         # FIXME: self.qualis estava dando erro de conversão; remediado temporariamente usando str(); verificar se comportamento está correto
         if nomeCompleto=="": # tratamento grupal
-            s +=  str(self.ano) +"\t"+ self.issn + "\t"+ self.doi +"\t"+ self.titulo +"\t"+ self.revista +"\t"+ self.autores +"\t"+ str(self.qualis) +"\t"+ str(self.qualissimilar)
+            s += (
+                f"{str(self.ano)}\t{self.doi}\t{self.issn}\t{self.titulo}\t"
+                f"{self.revista}\t \t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+            )
         else: # tratamento individual
-            s += nomeCompleto +"\t"+ str(self.ano) + "\t"+ self.issn + "\t" + self.doi +"\t"+ self.titulo +"\t"+ self.revista +"\t"+ self.autores +"\t"+ str(self.qualis) +"\t"+ (self.qualissimilar)
+            s += (
+                f"{nomeCompleto}\t{str(self.ano)}\t{self.doi}\t{self.issn}\t{self.titulo}\t"
+                f"{self.revista}\t \t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+            )
         return s
 
 

--- a/scriptLattes/producoesBibliograficas/resumoExpandidoEmCongresso.py
+++ b/scriptLattes/producoesBibliograficas/resumoExpandidoEmCongresso.py
@@ -196,9 +196,15 @@ class ResumoExpandidoEmCongresso:
             self.qualissimilar = ''
         s  = "resumoExpandidoEmCongresso\t"
         if nomeCompleto=="": # tratamento grupal
-            s +=  str(self.ano) +"\t"+ self.titulo +"\t"+ self.nomeDoEvento +"\t"+ self.autores +"\t"+ self.qualis +"\t"+ self.qualissimilar
+            s += (
+                f"{str(self.ano)}\t{self.doi}\t \t{self.titulo}\t \t"
+                f"{self.nomeDoEvento}\t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+            )
         else: # tratamento individual
-            s += nomeCompleto +"\t"+ str(self.ano) +"\t"+ self.titulo +"\t"+ self.nomeDoEvento +"\t"+ self.autores +"\t"+ self.qualis +"\t"+ self.qualissimilar
+            s += (
+                f"{nomeCompleto}\t{str(self.ano)}\t{self.doi}\t \t{self.titulo}\t \t"
+                f"{self.nomeDoEvento}\t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+            )
         return s
 
     # ------------------------------------------------------------------------ #

--- a/scriptLattes/producoesBibliograficas/trabalhoCompletoEmCongresso.py
+++ b/scriptLattes/producoesBibliograficas/trabalhoCompletoEmCongresso.py
@@ -220,13 +220,16 @@ class TrabalhoCompletoEmCongresso:
             self.qualissimilar = ''
         s = "trabalhoCompletoEmCongresso\t"
         if nomeCompleto == "":  # tratamento grupal
-            s += str(
-                self.ano) + "\t" + self.doi + "\t" + self.titulo + "\t" + self.nomeDoEvento + "\t" + self.autores + "\t" + self.qualis + "\t" + self.qualissimilar
+            s += (
+                f"{str(self.ano)}\t{self.doi}\t \t{self.titulo}\t \t"
+                f"{self.nomeDoEvento}\t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+            )
         else:  # tratamento individual
             try:
-                s += "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}".format(nomeCompleto, self.ano, self.doi,
-                                                                      self.titulo, self.nomeDoEvento, self.autores,
-                                                                      self.qualis, self.qualissimilar)
+                s += (
+                    f"{nomeCompleto}\t{str(self.ano)}\t{self.doi}\t \t{self.titulo}\t \t"
+                    f"{self.nomeDoEvento}\t{self.autores}\t{self.qualis}\t{self.qualissimilar}"
+                )
             except UnicodeDecodeError as err:
                 print(nomeCompleto)
                 print((str(self.ano)))


### PR DESCRIPTION
Uniformiza a ordem das colunas nos métodos CSV das classes `ArtigoEmPeriodico`, `ResumoExpandidoEmCongresso` e `TrabalhoCompletoEmCongresso`. Agora, as saídas CSV seguem uma sequência padrão, facilitando a análise e o processamento dos dados gerados. Caso alguma classe não possua valores para determinadas colunas, o campo correspondente será deixado em branco.

A sequência padrão de colunas é:

- tipo (ex: "trabalhoCompletoEmCongresso")
- nomeCompleto (para tratamento individual)
- ano
- doi
- issn
- titulo
- revista
- nomeDoEvento
- autores
- qualis
- qualissimilar