### PR TITLE
Configuração dinâmica de args do Chromedriver por variável de ambiente

### DIFF
--- a/scriptLattes/baixaLattes.py
+++ b/scriptLattes/baixaLattes.py
@@ -15,6 +15,9 @@ import warnings
 warnings.filterwarnings("ignore")
 
 RESULTS_DIR = os.environ.get('DATA_DIR', 'htmls')
+CHROMEDRIVER_ARGS = os.getenv('CHROMEDRIVE_ARGS').split(' ') \
+    if 'CHROMEDRIVER_ARGS' in os.environ \
+    else ['start-maximized', '--blink-settings=imagesEnabled=false', 'headless']
 URL = 'http://buscatextual.cnpq.br/buscatextual/preview.do?metodo=apresentar&id={0}'
 URL_LATTES_ID10 = 'http://buscatextual.cnpq.br/buscatextual/visualizacv.do?id={0}'
 URL_LATTES_ID16 = 'http://lattes.cnpq.br/{0}'
@@ -51,9 +54,8 @@ class LattesRobot:
 
     def create_driver(self):
         chrome_options = webdriver.ChromeOptions()
-        chrome_options.add_argument("start-maximized")
-        chrome_options.add_argument('--blink-settings=imagesEnabled=false') 
-        chrome_options.add_argument("headless")
+        for arg in CHROMEDRIVER_ARGS:
+            chrome_options.add_argument(arg)
         chrome_options.add_experimental_option("excludeSwitches", ["enable-automation"])
         chrome_options.add_experimental_option('useAutomationExtension', False)
         chrome_options.add_experimental_option('prefs', {'download.default_directory': self.results_dir})


### PR DESCRIPTION
# Contexto

Durante trabalho para permitir containerização do [ScriptLattes numa imagem Docker](https://github.com/igorjrd/scriptlattes-docker-image) para tornar mais fácil uso da CLI sem maiores preocupações com dependências e permitir integração em CI, notei que a atual forma do scriptLattes carece de um mecanismo para ajustar as configurações de inicialização do browser usado pelo selenium.

Como workaround, passei a utilizar de um [git patch](https://github.com/igorjrd/scriptlattes-docker-image/blob/main/git.patch) para adicionar um argumento de inicialização do chrome como etapa anterior ao build da imagem Docker que estive trabalhando, entretanto, creio que esta não é a melhor abordagem possível para sanar este problema.

Estou abrindo esse PR com uma alternativa que pode permitir configurações dinâmicas ao chromedriver, de forma a deixar o scriptLattes mais facilmente integrável em rotinas de CI e github actions, por exemplo.

# Alteração sugerida

Os parâmetros de inicialização ao navegador iniciado pelo chromedriver podem passar a ser definidos pela variável de ambiente CHROMEDRIVER_ARGS. Caso esta variável não esteja definida no shell que fez a execução do scriptLattes no sistema, o script irá considerar como default os parâmetros que já são utilizados atualmente.
